### PR TITLE
Change height/width limitation for narrow screens

### DIFF
--- a/client/web/css/global.css
+++ b/client/web/css/global.css
@@ -272,7 +272,7 @@ pre {
 
   .sr-main {
     width: 100%;
-    height: 305px;
+    min-width: 500px;
     background: rgb(247, 250, 252);
     box-shadow: 0px 0px 0px 0.5px rgba(50, 50, 93, 0.1),
       0px 2px 5px 0px rgba(50, 50, 93, 0.1),


### PR DESCRIPTION
Checkout demo here: https://codesandbox.io/s/laughing-currying-q66ty

When you shrink width of the screen, the display spills over both horizontally and vertically out of the gray outer box. Updating it so the width is at least 500px (barcode is just under that) and removing height limitation