### PR TITLE
Proper handle after modal closed

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -128,6 +128,7 @@ var payWithOxxo = function(stripe, clientSecret) {
         // Show error to your customer
         showError(result.error.message);
       }
+      changeLoadingState(false);
     });
 };
 

--- a/client/script.js
+++ b/client/script.js
@@ -6,13 +6,14 @@ var orderData = {
   currency: "mxn" // OXXO only accepts MXN
 };
 
-fetch("/create-payment-intent", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json"
-  },
-  body: JSON.stringify(orderData)
-})
+function createPaymentIntent() {
+  fetch("/create-payment-intent", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(orderData)
+  })
   .then(function(result) {
     return result.json();
   })
@@ -33,7 +34,7 @@ fetch("/create-payment-intent", {
         evt.preventDefault();
         // Initiate payment when the submit button is clicked
         payWithOxxo(stripe, clientSecret);
-      });
+      }, {once: true});
     document.querySelectorAll(".sr-pm-button").forEach(function(el) {
       el.addEventListener("click", function(evt) {
         // Handle switching between Card and OXXO
@@ -49,9 +50,12 @@ fetch("/create-payment-intent", {
           document.querySelector("#card-button").classList.remove("selected");
           document.querySelector("#oxxo-button").classList.add("selected");
         }
-      });
+      }, {once: true});
     });
   });
+}
+
+createPaymentIntent()
 
 // Set up Stripe.js and Elements to use in checkout form
 var setupElements = function(data) {
@@ -129,6 +133,7 @@ var payWithOxxo = function(stripe, clientSecret) {
         showError(result.error.message);
       }
       changeLoadingState(false);
+      createPaymentIntent()
     });
 };
 


### PR DESCRIPTION
To solve this issue I:

- Created the function `createPaymentIntent` which is called when the site loads and after the voucher that contains the modal is closed. 
- Made the onclick events work once.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/64553760/87102026-36a3e080-c216-11ea-8e5b-03a51172e688.gif)
